### PR TITLE
 Fix: Multiple bug fixes across User, Manager, and Admin dashboard

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -44,8 +44,10 @@ function timeAgo(string $dt): string {
 <body class="page-admin">
 <canvas id="bg-canvas"></canvas>
 
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
 <div class="shell">
-    <aside class="sidebar">
+    <aside class="sidebar" id="adminSidebar">
         <div class="sidebar-brand">
             <div class="brand-dot"></div>
             <div class="brand-texts"><h2>NBSC Admin</h2><p>System Administrator</p></div>
@@ -77,7 +79,11 @@ function timeAgo(string $dt): string {
 
     <main class="main">
         <div class="topbar">
-            <div><div id="page-title">Dashboard</div><div class="topbar-sub" id="topbar-sub">System overview</div></div>
+            <div style="display:flex;align-items:center;gap:12px;">
+                <button class="menu-toggle" id="menuToggle">☰</button>
+                <span class="topbar-elpms">ELPMS</span>
+                <div><div id="page-title">Dashboard</div><div class="topbar-sub" id="topbar-sub">System overview</div></div>
+            </div>
             <div class="admin-pill">
                 <div class="admin-avatar">AD</div>
                 <span><?= htmlspecialchars($user['name']) ?></span>

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -212,6 +212,9 @@ function timeAgo(string $dt): string {
     </div>
 </div>
 
+<script>
+window.BASE_URL = "<?= url('') ?>";
+</script>
 <script src="<?= url('assets/js/admin.js') ?>"></script>
 </body>
 </html>

--- a/api/admin.php
+++ b/api/admin.php
@@ -79,7 +79,6 @@ if ($method === 'POST') {
             exit;
         }
 
-        $exists = $pdo->prepare("SELECT id FROM users WHERE email = ?")->execute([$email]);
         $exists = $pdo->prepare("SELECT id FROM users WHERE email = ?");
         $exists->execute([$email]);
         if ($exists->fetch()) {

--- a/api/latest_readings.php
+++ b/api/latest_readings.php
@@ -1,0 +1,21 @@
+<?php
+// Returns the current lux and pollution level for every building.
+// Reads from the buildings table which is kept up to date by log_readings.php.
+// Falls back to light_logs if needed. Requires login since it is dashboard data.
+
+require_once __DIR__ . '/../config/db.php';
+require_once __DIR__ . '/../config/session.php';
+
+header('Content-Type: application/json');
+
+requireLogin();
+
+// Primary source: buildings table (always current, updated every 60s by main.js)
+$rows = $pdo->query(
+    "SELECT id AS building_id, lux, pollution_level, online,
+            name, lat, lng, description
+     FROM buildings
+     ORDER BY id ASC"
+)->fetchAll();
+
+echo json_encode(['success' => true, 'readings' => $rows]);

--- a/api/log_readings.php
+++ b/api/log_readings.php
@@ -1,6 +1,7 @@
 <?php
 // Receives a JSON batch of sensor readings from main.js and saves them to light_logs.
-// Called automatically by the frontend once per minute.
+// Also updates the buildings table so all other pages reflect the latest levels.
+// Called automatically by the frontend every 60 seconds.
 
 require_once __DIR__ . '/../config/db.php';
 require_once __DIR__ . '/../config/config.php';
@@ -21,21 +22,41 @@ if (empty($body['entries']) || !is_array($body['entries'])) {
     exit;
 }
 
-// Insert all entries in a single prepared statement loop
-$stmt = $pdo->prepare(
+$insertLog = $pdo->prepare(
     "INSERT INTO light_logs (building_id, lux, pollution_level, online) VALUES (?, ?, ?, ?)"
 );
+
+// Also update the buildings table so manager and other pages see current levels
+$updateBuilding = $pdo->prepare(
+    "UPDATE buildings SET lux = ?, pollution_level = ?, online = ? WHERE id = ?"
+);
+
+// Keep only the latest entry per building for the buildings table update
+$latest = [];
+foreach ($body['entries'] as $entry) {
+    $latest[(int)$entry['building_id']] = $entry;
+}
 
 $pdo->beginTransaction();
 try {
     foreach ($body['entries'] as $entry) {
-        $stmt->execute([
+        $insertLog->execute([
             (int)$entry['building_id'],
             (float)$entry['lux'],
             $entry['pollution_level'],
             (int)$entry['online'],
         ]);
     }
+
+    foreach ($latest as $id => $entry) {
+        $updateBuilding->execute([
+            (float)$entry['lux'],
+            $entry['pollution_level'],
+            (int)$entry['online'],
+            $id,
+        ]);
+    }
+
     $pdo->commit();
     echo json_encode(['success' => true, 'saved' => count($body['entries'])]);
 } catch (PDOException $e) {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -789,7 +789,7 @@ body.page-user { overflow-x: hidden; overflow-y: scroll; }
 body.page-manager,
 body.page-admin { overflow: hidden; }
 
-.shell { position: relative; z-index: 1; display: flex; height: 100vh; overflow: hidden; }
+.shell { position: relative; display: flex; height: 100vh; overflow: hidden; }
 
 .sidebar {
     width: var(--sidebar-w);
@@ -1187,7 +1187,7 @@ tbody tr:last-child td { border-bottom: none; }
     /* Manager / Admin shell */
     .menu-toggle  { display: flex; }
     .topbar-elpms { display: inline; }
-    .sidebar { position: fixed; left: -240px; z-index: 100; }
+    .sidebar { position: fixed; top: 0; left: -240px; z-index: 100; height: 100vh; }
     .sidebar.open { left: 0; }
     .topbar { padding: 0 14px; height: 56px; }
     #page-title { font-size: 1rem; max-width: 200px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -1250,4 +1250,13 @@ tbody tr:last-child td { border-bottom: none; }
     .kpi .value { font-size: 0.9rem; }
     .tab-btn span { display: none; }
     .stat-num { font-size: 1.1rem; }
+}
+
+/* On mobile, allow the fixed sidebar to escape the shell's overflow clipping.
+   Scoped to admin and manager only, and only below 768px. */
+@media (max-width: 768px) {
+    body.page-admin .shell,
+    body.page-manager .shell {
+        overflow: visible;
+    }
 }

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -5,7 +5,23 @@ let editingUserId = null;
 
 // Section navigation
 document.querySelectorAll('.nav-item[data-section]').forEach(btn => {
-    btn.addEventListener('click', () => navigate(btn.dataset.section));
+    btn.addEventListener('click', () => {
+        navigate(btn.dataset.section);
+        // Close sidebar drawer on mobile after nav item is tapped
+        document.getElementById('adminSidebar')?.classList.remove('open');
+        document.getElementById('sidebarOverlay')?.classList.remove('open');
+    });
+});
+
+// Hamburger menu toggle for mobile
+document.getElementById('menuToggle')?.addEventListener('click', () => {
+    document.getElementById('adminSidebar')?.classList.toggle('open');
+    document.getElementById('sidebarOverlay')?.classList.toggle('open');
+});
+
+document.getElementById('sidebarOverlay')?.addEventListener('click', () => {
+    document.getElementById('adminSidebar')?.classList.remove('open');
+    document.getElementById('sidebarOverlay')?.classList.remove('open');
 });
 
 function navigate(section) {

--- a/assets/js/manager.js
+++ b/assets/js/manager.js
@@ -195,7 +195,8 @@ function initManagerMap() {
     L.control.layers({ 'Standard': std, 'Satellite': sat }, null, { position: 'bottomright' }).addTo(adminMap);
     adminMap.on('baselayerchange', e => adminMap.getContainer().classList.toggle('satellite-active', e.name === 'Satellite'));
 
-    renderManagerMarkers('all');
+    // Sync from DB immediately when the map section is opened so markers are current
+    syncBuildingLevels().then(() => renderManagerMarkers('all'));
 }
 
 function renderManagerMarkers(filter) {
@@ -258,3 +259,48 @@ document.getElementById('building-modal').addEventListener('click', e => { if (e
 
     loop();
 })();
+
+// Fetches the latest building levels from DB and updates building cards and map markers.
+// Runs every 30 seconds so the manager sees live pollution data without refreshing.
+async function syncBuildingLevels() {
+    try {
+        const res  = await fetch(API('api/latest_readings.php'));
+        const data = await res.json();
+        if (!data.success || !data.readings.length) return;
+
+        data.readings.forEach(row => {
+            const id    = parseInt(row.building_id);
+            const level = row.pollution_level;
+            const color = POLLUTION_COLORS[level];
+
+            // Update the local BUILDINGS array so map re-renders use fresh data
+            const b = BUILDINGS.find(x => x.id === id);
+            if (b) {
+                b.pollution_level = level;
+                b.lux = parseFloat(row.lux);
+            }
+
+            // Update the badge on the building card
+            const card  = document.getElementById('bcard-' + id);
+            if (card) {
+                const badge = card.querySelector('.badge');
+                if (badge) {
+                    badge.className  = 'badge ' + level;
+                    badge.textContent = level.charAt(0).toUpperCase() + level.slice(1);
+                }
+                card.dataset.level = level;
+            }
+        });
+
+        // Re-render map markers if the map is open so colors update
+        if (adminMap) {
+            const currentFilter = document.getElementById('map-filter')?.value || 'all';
+            renderManagerMarkers(currentFilter);
+        }
+    } catch (e) {}
+}
+
+// Run once immediately on page load so data is current from the first render,
+// then keep syncing every 30 seconds
+syncBuildingLevels();
+setInterval(syncBuildingLevels, 30000);

--- a/assets/js/user.js
+++ b/assets/js/user.js
@@ -5,7 +5,29 @@ const POLLUTION_COLORS = { low: '#22c55e', moderate: '#f59e0b', high: '#ef4444' 
 const cap = s => s ? s.charAt(0).toUpperCase() + s.slice(1) : '';
 
 let userMap    = null;
-let mapMarkers = [];
+let mapMarkers = {};
+
+// Local working copy of building data, updated on each simulation tick
+const buildings = BUILDINGS_DATA.map(b => ({ ...b }));
+
+function getLevelFromLux(lux) {
+    if (lux < 30) return 'low';
+    if (lux < 80) return 'moderate';
+    return 'high';
+}
+
+function buildUserPopup(b) {
+    const color = POLLUTION_COLORS[b.pollutionLevel];
+    return `
+        <div style="font-family:'Outfit',sans-serif;min-width:170px;">
+            <div style="font-weight:700;font-size:0.92rem;margin-bottom:6px;">${b.name}</div>
+            <span style="display:inline-block;padding:2px 8px;border-radius:10px;font-size:0.72rem;font-weight:600;background:${color}33;color:${color};border:1px solid ${color}66;">
+                ${cap(b.pollutionLevel)}
+            </span>
+            <div style="font-size:0.78rem;color:#777;margin-top:4px;">${b.description}</div>
+            <div style="font-size:0.75rem;color:#aaa;margin-top:4px;">Lux: ${typeof b.lux === 'number' ? b.lux.toFixed(1) : b.lux}</div>
+        </div>`;
+}
 
 function initUserMap() {
     if (userMap) return;
@@ -28,32 +50,93 @@ function initUserMap() {
         .addTo(userMap)
         .bindPopup('Northern Bukidnon State College');
 
-    renderMapMarkers('all');
+    // Place initial markers keyed by building id
+    buildings.forEach(b => {
+        const color  = POLLUTION_COLORS[b.pollutionLevel];
+        const marker = L.circleMarker(b.coordinates, {
+            radius: 10, fillColor: color, color: '#fff', weight: 2, fillOpacity: 0.9,
+        }).addTo(userMap);
+        marker.bindPopup(buildUserPopup(b));
+        mapMarkers[b.id] = marker;
+    });
+
+    // Sync immediately from DB on load, then every 30 seconds
+    syncFromDatabase();
+    setInterval(syncFromDatabase, 30000);
 }
 
-function renderMapMarkers(filter) {
-    mapMarkers.forEach(m => userMap.removeLayer(m));
-    mapMarkers = [];
+// Fetches the latest reading per building from the DB and updates all markers.
+// Falls back to local random simulation if the DB has no entries yet.
+async function syncFromDatabase() {
+    try {
+        const res  = await fetch(API('api/latest_readings.php'));
+        const data = await res.json();
 
-    BUILDINGS_DATA
-        .filter(b => filter === 'all' || b.pollutionLevel === filter)
-        .forEach(b => {
-            const color  = POLLUTION_COLORS[b.pollutionLevel];
-            const marker = L.circleMarker(b.coordinates, {
-                radius: 10, fillColor: color, color: '#fff', weight: 2, fillOpacity: 0.9,
-            }).addTo(userMap);
+        if (data.success && data.readings.length > 0) {
+            const filter = document.getElementById('user-map-filter')?.value || 'all';
 
-            marker.bindPopup(`
-                <div style="font-family:'Outfit',sans-serif;min-width:170px;">
-                    <div style="font-weight:700;font-size:0.92rem;margin-bottom:6px;">${b.name}</div>
-                    <span style="display:inline-block;padding:2px 8px;border-radius:10px;font-size:0.72rem;font-weight:600;background:${color}33;color:${color};border:1px solid ${color}66;">
-                        ${cap(b.pollutionLevel)}
-                    </span>
-                    <div style="font-size:0.78rem;color:#777;margin-top:4px;">${b.description}</div>
-                </div>`);
+            data.readings.forEach(row => {
+                const b = buildings.find(x => x.id === parseInt(row.building_id));
+                if (!b) return;
 
-            mapMarkers.push(marker);
-        });
+                b.lux            = parseFloat(row.lux);
+                b.pollutionLevel = row.pollution_level;
+                b.online         = !!parseInt(row.online);
+
+                const marker = mapMarkers[b.id];
+                if (!marker) return;
+
+                marker.setStyle({ fillColor: POLLUTION_COLORS[b.pollutionLevel] });
+                marker.setPopupContent(buildUserPopup(b));
+
+                if (filter === 'all' || b.pollutionLevel === filter) {
+                    if (!userMap.hasLayer(marker)) marker.addTo(userMap);
+                } else {
+                    if (userMap.hasLayer(marker)) userMap.removeLayer(marker);
+                }
+            });
+        } else {
+            // No DB data yet — run local simulation so the map still shows live-looking data
+            runLocalSimulation();
+        }
+    } catch (e) {
+        // Network error — fall back to local simulation
+        runLocalSimulation();
+    }
+}
+
+// Local fallback simulation used only when the DB has no readings yet
+function runLocalSimulation() {
+    const filter = document.getElementById('user-map-filter')?.value || 'all';
+
+    buildings.forEach(b => {
+        b.lux            = Math.min(150, Math.max(5, b.lux + (Math.random() - 0.5) * 15));
+        b.pollutionLevel = getLevelFromLux(b.lux);
+
+        const marker = mapMarkers[b.id];
+        if (!marker) return;
+
+        marker.setStyle({ fillColor: POLLUTION_COLORS[b.pollutionLevel] });
+        marker.setPopupContent(buildUserPopup(b));
+
+        if (filter === 'all' || b.pollutionLevel === filter) {
+            if (!userMap.hasLayer(marker)) marker.addTo(userMap);
+        } else {
+            if (userMap.hasLayer(marker)) userMap.removeLayer(marker);
+        }
+    });
+}
+
+function applyMapFilter(filter) {
+    buildings.forEach(b => {
+        const marker = mapMarkers[b.id];
+        if (!marker) return;
+        if (filter === 'all' || b.pollutionLevel === filter) {
+            if (!userMap.hasLayer(marker)) marker.addTo(userMap);
+        } else {
+            if (userMap.hasLayer(marker)) userMap.removeLayer(marker);
+        }
+    });
 }
 
 document.querySelectorAll('.tab-btn').forEach(btn => {
@@ -67,8 +150,11 @@ document.querySelectorAll('.tab-btn').forEach(btn => {
     });
 });
 
-document.getElementById('user-map-filter').addEventListener('change', e => renderMapMarkers(e.target.value));
-document.getElementById('refresh-user-map-btn').addEventListener('click', () => renderMapMarkers(document.getElementById('user-map-filter').value));
+document.getElementById('user-map-filter').addEventListener('change', e => applyMapFilter(e.target.value));
+document.getElementById('refresh-user-map-btn').addEventListener('click', async () => {
+    await syncFromDatabase();
+    applyMapFilter(document.getElementById('user-map-filter').value);
+});
 document.getElementById('reset-user-map-btn').addEventListener('click', () => userMap?.setView([8.359999, 124.868103], 18));
 
 const pill     = document.getElementById('userPillToggle');
@@ -143,7 +229,7 @@ async function downloadCSV(reqId, buildingId, location, startDate, endDate, data
     document.body.removeChild(a);
 }
 
-// Shared animated particle background used by all dashboard pages
+// Animated particle background
 (function () {
     const canvas = document.getElementById('bg-canvas');
     const ctx    = canvas.getContext('2d');

--- a/config/session.php
+++ b/config/session.php
@@ -3,6 +3,14 @@
 // Include this at the top of every protected PHP page.
 
 if (session_status() === PHP_SESSION_NONE) {
+    // lifetime 0 means the session cookie is deleted when the browser tab closes
+    session_set_cookie_params([
+        'lifetime' => 0,
+        'path'     => '/',
+        'secure'   => false,
+        'httponly' => true,
+        'samesite' => 'Lax',
+    ]);
     session_start();
 }
 

--- a/index.php
+++ b/index.php
@@ -3,7 +3,18 @@ require_once __DIR__ . '/config/session.php';
 require_once __DIR__ . '/config/config.php';
 require_once __DIR__ . '/config/db.php';
 
-$user = isLoggedIn() ? currentUser() : null;
+// Logged-in users who navigate to the landing page are sent to their dashboard
+if (isLoggedIn()) {
+    $dest = match($_SESSION['role']) {
+        'admin'   => url('admin/admin.php'),
+        'manager' => url('manager/manager.php'),
+        default   => url('user/user.php'),
+    };
+    header('Location: ' . $dest);
+    exit;
+}
+
+$user = null;
 
 // Load all buildings from the database for map markers and the log table
 $buildings = $pdo->query("SELECT * FROM buildings ORDER BY id ASC")->fetchAll();

--- a/user/user.php
+++ b/user/user.php
@@ -69,10 +69,10 @@ function timeAgo(string $datetime): string {
                 <div class="dropdown-user-name"><?= htmlspecialchars($user['name']) ?></div>
                 <div class="dropdown-user-email"><?= htmlspecialchars($user['email']) ?></div>
             </div>
-            <button class="dropdown-item-btn" onclick="window.location.href="<?= url('index.php') ?>"">
+            <a href="<?= url('user/user.php') ?>" class="dropdown-item-btn" style="text-decoration:none;">
                 <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" fill="currentColor" viewBox="0 0 16 16"><path d="M8.354 1.146a.5.5 0 0 0-.708 0l-6 6A.5.5 0 0 0 1.5 7.5v7a.5.5 0 0 0 .5.5h4a.5.5 0 0 0 .5-.5v-4h3v4a.5.5 0 0 0 .5.5h4a.5.5 0 0 0 .5-.5v-7a.5.5 0 0 0-.146-.354L8.354 1.146z"/></svg>
                 Back to Home
-            </button>
+            </a>
             <a href="<?= url('logout.php') ?>" class="dropdown-item-btn danger" style="text-decoration:none;">
                 <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" fill="currentColor" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M10 12.5a.5.5 0 0 1-.5.5h-8a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5h8a.5.5 0 0 1 .5.5v2a.5.5 0 0 0 1 0v-2A1.5 1.5 0 0 0 9.5 2h-8A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h8a1.5 1.5 0 0 0 1.5-1.5v-2a.5.5 0 0 0-1 0v2z"/><path fill-rule="evenodd" d="M15.854 8.354a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708.708L14.293 7.5H5.5a.5.5 0 0 0 0 1h8.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3z"/></svg>
                 Logout
@@ -278,6 +278,8 @@ const BUILDINGS_DATA = <?= json_encode(array_map(fn($b) => [
     'coordinates'    => [(float)$b['lat'], (float)$b['lng']],
     'pollutionLevel' => $b['pollution_level'],
     'description'    => $b['description'] ?? '',
+    'lux'            => (float)$b['lux'],
+    'online'         => (bool)$b['online'],
 ], $buildings), JSON_HEX_TAG) ?>;
 </script>
 <script src="<?= url('assets/js/user.js') ?>"></script>


### PR DESCRIPTION

**Description/Summary**

This pull request resolves 5 reported issues and several sub-issues discovered during investigation across the landing page, user dashboard, manager dashboard, and admin dashboard. The fixes address session persistence, broken navigation, live data synchronization between the simulation and all role dashboards, disconnected admin user management actions, and a missing mobile sidebar on the admin panel. All changes are scoped to their affected files with no unintended side effects on other pages or screen sizes.

---

**Changes Made**

**Issue #1 — Authenticated session persists on landing page after tab close**

Session cookie was not expiring when the browser tab closed, causing the previous user's account to appear on the landing page on next visit. Additionally, a logged-in user could manually navigate to the landing page instead of being redirected to their dashboard.

Added `session_set_cookie_params(['lifetime' => 0])` before `session_start()` so the session cookie is destroyed when the tab or browser window closes. Added a role-based redirect block at the top of `index.php` so any logged-in user hitting the landing page is immediately sent to their corresponding dashboard.

---

**Issue #2 — Back to Home button in user dropdown not functioning**

The button used a `<button>` element with an `onclick` attribute where PHP-generated double quotes were nested inside HTML double quotes, producing malformed HTML that silently failed on click.

Replaced with a proper `<a>` anchor tag pointing to `user/user.php`. Since the campus map tab is the default active tab on load, clicking it reloads the dashboard and lands the user on the map section as intended.

---

**Issue #3 — Live pollution data not reflecting across User and Manager dashboards**

Multiple compounding root causes were found. The `buildings` table was never updated by the simulation — `log_readings.php` only wrote to `light_logs`, so every page that reads from `buildings` always showed static seed values. The `BUILDINGS_DATA` injected into `user.php` was missing the `lux` and `online` fields, causing `lux = undefined` in JavaScript. `getLevelFromLux(NaN)` always returned `high`, making every marker permanently red. The user map refresh button called `syncFromDatabase()` and `applyMapFilter()` back-to-back without awaiting the async fetch, so the filter applied before new data arrived. The manager page had no live sync at all.

Updated `log_readings.php` to also run `UPDATE buildings SET lux, pollution_level, online` on every save so the `buildings` table is always current. Created `api/latest_readings.php` which reads directly from `buildings`, returning live values without depending on `light_logs`. Added `lux` and `online` to the `BUILDINGS_DATA` injection in `user.php`. Changed the refresh button handler to `async` with `await syncFromDatabase()`. Added `syncBuildingLevels()` to `manager.js` which fetches from `latest_readings.php` immediately on page load, every 30 seconds, and whenever the map section is opened.

The corrected data flow is as follows. The landing page simulation updates markers every 30 seconds and writes to both `light_logs` and `buildings` every 60 seconds. The user map fetches from `latest_readings.php` every 30 seconds and immediately on manual refresh. The manager building cards and campus map update badge colors and marker colors immediately on load and every 30 seconds thereafter.

---

**Issue #4 — Admin user management actions not connecting to database**

The Add Account, Edit Role, and Delete actions all opened their modals correctly but silently failed without making any changes to the database. `window.BASE_URL` was never injected into `admin.php` before `admin.js` loaded. The `API()` helper resolved to `/api/admin.php` instead of `/lpms/api/admin.php`, sending every fetch to the wrong URL. A secondary dead duplicate `prepare()->execute()` call existed in the `add_user` handler.

Added the missing `<script>window.BASE_URL = "<?= url('') ?>";</script>` block before the external script tag in `admin.php`, matching the same pattern already used in `manager.php` and `user.php`. Removed the duplicate prepare call in `api/admin.php`.

---

**Issue #5 — No sidebar on mobile view of Admin dashboard**

The admin sidebar was not accessible on mobile. The CSS rules for the hamburger menu, sidebar overlay, and mobile sidebar behavior already existed and were working correctly on the manager page, but the admin page was missing the corresponding HTML elements and JavaScript logic entirely. Additionally, `.shell` having `overflow: hidden` on mobile created a clipping context that prevented `position: fixed` children from rendering outside the element bounds, which affected both admin and manager.

Added `<div class="sidebar-overlay" id="sidebarOverlay">`, hamburger `<button class="menu-toggle" id="menuToggle">☰</button>`, and `<span class="topbar-elpms">` to the admin topbar. Added toggle logic in `admin.js` for the hamburger click, overlay click to dismiss, and auto-close on nav item tap. Added a scoped CSS rule that sets `overflow: visible` on `.shell` for `body.page-admin` and `body.page-manager` at mobile width only, leaving desktop layout and all other pages completely untouched.

---

**Testing**

Issue #1 — Log in as any role, close the tab, reopen the landing page. Confirm no account appears in the navbar. Log in again and manually type the landing page URL. Confirm redirect to the correct dashboard.

Issue #2 — Log in as a user, open the dropdown, click Back to Home. Confirm the page reloads and lands on the campus map tab.

Issue #3 — Open the landing page and leave it running. After 60 seconds, open the user dashboard and confirm map marker colors reflect the current simulation. Click Refresh and confirm markers update immediately. Open the manager dashboard, navigate to Buildings and Campus Map, and confirm badge colors and marker colors match the current readings without a hard page refresh.

Issue #4 — Log in as admin, navigate to Users Management. Add a new account, verify it appears in the table and exists in the database. Edit the role of an existing user, verify the badge updates. Delete a user, verify they are removed from the table and the database.

Issue #5 — Open the admin dashboard on a mobile screen or at viewport width below 768px. Confirm the hamburger button appears in the topbar. Tap it and confirm the sidebar slides in. Tap a nav item and confirm the sidebar closes and the correct section loads. Tap outside the sidebar and confirm it closes.

---

**Table of Changed Files**

| File | Type | Description |
|---|---|---|
| `config/session.php` | Modified | Session cookie lifetime set to 0 so it expires on tab close |
| `index.php` | Modified | Added redirect for logged-in users to their role dashboard |
| `user/user.php` | Modified | Fixed Back to Home button, added lux and online to BUILDINGS_DATA |
| `assets/js/user.js` | Modified | DB-synced map via latest_readings.php, fixed async refresh button |
| `assets/js/manager.js` | Modified | Added syncBuildingLevels on load, on interval, and on map open |
| `assets/js/admin.js` | Modified | Added hamburger menu toggle logic |
| `api/log_readings.php` | Modified | Now also updates buildings table on every save batch |
| `api/latest_readings.php` | New | Returns current lux and pollution level per building from buildings table |
| `api/admin.php` | Modified | Removed duplicate prepare call in add_user handler |
| `admin/admin.php` | Modified | Added BASE_URL injection, hamburger button, sidebar overlay element |
| `assets/css/styles.css` | Modified | Added scoped mobile overflow fix for admin and manager shell |